### PR TITLE
use reticulate to install fluxnet-shuttle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     processx,
     rappdirs,
     readr,
+    reticulate (>= 1.41),
     stringr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/flux_download.R
+++ b/R/flux_download.R
@@ -49,19 +49,20 @@ flux_listall <- function(
     nrow(cached_snapshots |> dplyr::filter(!expired)) == 0 |
       isFALSE(use_cache)
   ) {
-    # Check that fluxnet-shuttle is installed
-    shuttle_installed <- processx::run(
-      "which",
-      "fluxnet-shuttle",
-      error_on_status = FALSE,
-      stderr = NULL,
-      stdout = NULL
-    )
-    if (shuttle_installed$status > 0) {
-      cli::cli_abort(
-        "To use {.fn flux_listall}, install the {.code fluxnet-shuttle} command-line utility at {.url https://github.com/fluxnet/shuttle}."
-      )
-    }
+    # # Check that fluxnet-shuttle is installed
+    # shuttle_installed <- processx::run(
+    #   "which",
+    #   "fluxnet-shuttle",
+    #   error_on_status = FALSE,
+    #   stderr = NULL,
+    #   stdout = NULL
+    # )
+    # if (shuttle_installed$status > 0) {
+    #   cli::cli_abort(
+    #     "To use {.fn flux_listall}, install the {.code fluxnet-shuttle} command-line utility at {.url https://github.com/fluxnet/shuttle}."
+    #   )
+    # }
+    fluxnet_shuttle <- fluxnet_shuttle_executable("fluxnet")
     cli::cli_inform("File list is expired, downloading the latest version")
     # Run from cache_dir instead of supplying cache_dir to -o flag because -l flag to set path
     # of logfile doesn't work (https://github.com/fluxnet/shuttle/issues/104)
@@ -71,7 +72,7 @@ flux_listall <- function(
       log_cmd <- c("-l", log_file)
     }
     listall <- processx::run(
-      "fluxnet-shuttle",
+      fluxnet_shuttle,
       c(log_cmd, "listall", "-o", fs::path_expand(cache_dir)),
       echo_cmd = echo_cmd
     )

--- a/R/fluxnet_shuttle_executable.R
+++ b/R/fluxnet_shuttle_executable.R
@@ -1,0 +1,13 @@
+#' Big thanks to Andrew Heiss for helping me figure this out!
+fluxnet_shuttle_executable <- function(virtualenv = "fluxnet") {
+  #TODO: check if virtualenv already exists and print message if not
+  reticulate::virtualenv_create(
+    virtualenv,
+    version = ">=3.11,<3.14",
+    packages = "git+https://github.com/fluxnet/shuttle.git"
+  )
+  env_path <- reticulate::virtualenv_python(virtualenv)
+  executable <- file.path(dirname(env_path), "fluxnet-shuttle")
+
+  executable
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,6 @@
+.onLoad <- function(...) {
+  reticulate::py_require(
+    packages = "git+https://github.com/fluxnet/shuttle.git",
+    python_version = ">=3.11,<3.14"
+  )
+}


### PR DESCRIPTION
I think we're on the right track here.  Now, when you run `flux_listall()` for the first time, it'll use the `reticulate` package to create a virtual environment with `fluxnet-shuttle` installed (unless it already exists).  You must have python version 3.11–3.13 installed (it'll prompt you with instructions if you don't or it cant find it) because that's what `fluxnet-shuttle` requires.

What I haven't figured out is if this should be a separate step and more verbose or if it should just be part of `flux_listall()` like it is now.