### PR TITLE
Improve flux_download()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # fluxnet (development version)
 
+* `flux_download()` now retries failed downloads once and `overwrite = FALSE` no longer skips downloading corrupted or partial downloads.
 * Added `flux_read()` for reading in FLUXNET data in a manifest.
 * Added `flux_discover_files()` for creating a file manifest.
 

--- a/man/flux_download.Rd
+++ b/man/flux_download.Rd
@@ -31,7 +31,9 @@ a vector of site IDs. For example, \code{c("UK-GaB", "CA-Ca2")}.}
 
 \item{download_dir}{The directory to download zip files to.}
 
-\item{overwrite}{Logical; overwrite already downloaded .zip files?}
+\item{overwrite}{Logical; overwrite already downloaded .zip files? If \code{FALSE}
+it will skip downloading existing files, unless they are invalid .zip files
+(e.g. due to partial download or corruption).}
 
 \item{use_cache}{Logical; use cached list of files available to download if
 it exists and is not older than \code{cache_age}?}


### PR DESCRIPTION
`flux_download()` now retries failed downloads once.  It also now tries to resume download or re-download partial or corrupted zip files even when `overwrite = FALSE`