### PR TITLE
Add startup message

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,7 @@
   cli::cli_div(theme = list(span.emph = list(color = "orange")))
   cli::cli_inform(
     c(
-      "!" = "Please abide by FLUXNET data policies: {.url https://fluxnet.org/data/data-policy/}",
+      "!" = "Use of data downloaded by {.pkg fluxnet} requires you abide by FLUXNET data policies: {.url https://fluxnet.org/data/data-policy/}",
       i = "Citations for individual sites' datasets are returned by {.fun fluxnet::flux_listall}"
     ),
     class = "packageStartupMessage"


### PR DESCRIPTION
Adds this message whenever `library(fluxnet)` is run

```
> library(fluxnet)
! Please abide by FLUXNET data policies: <[https://fluxnet.org/data/data-policy/]>
ℹ Citations for individual sites' datasets are returned by `fluxnet::flux_listall()`
```
<img width="639" height="99" alt="Screenshot 2026-02-26 at 2 34 13 PM" src="https://github.com/user-attachments/assets/f3d0051b-97d8-4455-ab28-10ec01776dfa" />


Both the URL and the `flunet::flux_listall()` are clickable