### PR TITLE
fix condition > 1 errors with `site_ids` arg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fluxnet (development version)
 
+* Fixes a bug introduced in 0.3.1 when more than one site id is provided to `site_ids`.
+
 # fluxnet 0.3.1
 
 * `site_ids = "all"` is deprecated in favor of `site_ids = NULL` in all functions with this argument.

--- a/R/flux_badm.R
+++ b/R/flux_badm.R
@@ -32,7 +32,7 @@ flux_badm <- function(
   )
 ) {
   if (!is.null(site_ids)) {
-    if (site_ids == "all") {
+    if (any(site_ids == "all")) {
       cli::cli_warn(
         "Setting {.arg site_ids = 'all'} is deprecated. Using {.arg site_ids = NULL} instead."
       )

--- a/R/flux_download.R
+++ b/R/flux_download.R
@@ -53,7 +53,7 @@ flux_download <- function(
   ...
 ) {
   if (!is.null(site_ids)) {
-    if (site_ids == "all") {
+    if (any(site_ids == "all")) {
       cli::cli_warn(
         "Setting {.arg site_ids = 'all'} is deprecated. Using {.arg site_ids = NULL} instead."
       )

--- a/R/flux_extract.R
+++ b/R/flux_extract.R
@@ -48,7 +48,7 @@ flux_extract <- function(
   overwrite = FALSE
 ) {
   if (!is.null(site_ids)) {
-    if (site_ids == "all") {
+    if (any(site_ids == "all")) {
       cli::cli_warn(
         "Setting {.arg site_ids = 'all'} is deprecated. Using {.arg site_ids = NULL} instead."
       )

--- a/R/flux_read.R
+++ b/R/flux_read.R
@@ -49,7 +49,7 @@ flux_read <- function(
   site_ids = NULL
 ) {
   if (!is.null(site_ids)) {
-    if (site_ids == "all") {
+    if (any(site_ids == "all")) {
       cli::cli_warn(
         "Setting {.arg site_ids = 'all'} is deprecated. Using {.arg site_ids = NULL} instead."
       )

--- a/R/flux_varinfo.R
+++ b/R/flux_varinfo.R
@@ -38,7 +38,7 @@ flux_varinfo <- function(
   site_ids = NULL
 ) {
   if (!is.null(site_ids)) {
-    if (site_ids == "all") {
+    if (any(site_ids == "all")) {
       cli::cli_warn(
         "Setting {.arg site_ids = 'all'} is deprecated. Using {.arg site_ids = NULL} instead."
       )

--- a/tests/testthat/test-flux_extract.R
+++ b/tests/testthat/test-flux_extract.R
@@ -46,3 +46,16 @@ test_that("network arg works", {
     )
   )
 })
+
+test_that("site_ids works", {
+  tmpdir <- withr::local_tempdir()
+  out <- flux_extract(
+    zip_dir = test_path("testdata"),
+    output_dir = tmpdir,
+    site_ids = c("AR-CCg", "AU-Wom"),
+    resolutions = c("y"),
+    extract_varinfo = FALSE,
+    extract_txt = FALSE
+  )
+  expect_s3_class(out, "data.frame")
+})


### PR DESCRIPTION
Fixes an error introduced when `site_ids = "all"` was deprecated