### PR TITLE
VARINFO files are apparently latin1 encoded, not utf8

### DIFF
--- a/R/flux_varinfo.R
+++ b/R/flux_varinfo.R
@@ -62,7 +62,7 @@ flux_varinfo <- function(
   # parsed
   var_info_raw <- readr::read_csv(
     files_df$path,
-    locale = locale(encoding = "latin1"),
+    locale = readr::locale(encoding = "latin1"),
     show_col_types = FALSE
   ) %>%
     dplyr::filter(.data$VARIABLE_GROUP %in% c("VAR_INFO", "GRP_VAR_INFO"))

--- a/R/flux_varinfo.R
+++ b/R/flux_varinfo.R
@@ -58,7 +58,13 @@ flux_varinfo <- function(
     files_df <- files_df %>% dplyr::filter(.data$site_id %in% site_ids)
   }
 
-  var_info_raw <- readr::read_csv(files_df$path, show_col_types = FALSE) %>%
+  # Convert from latin1 encoding to UTF-8 encoding to get "µ" symbol correctly
+  # parsed
+  var_info_raw <- readr::read_csv(
+    files_df$path,
+    locale = locale(encoding = "latin1"),
+    show_col_types = FALSE
+  ) %>%
     dplyr::filter(.data$VARIABLE_GROUP %in% c("VAR_INFO", "GRP_VAR_INFO"))
 
   var_info_tidy <- var_info_raw %>%


### PR DESCRIPTION
Fixes issue with parsing "µ" from the BIFVARINFO csv files.  Apparently they are latin1 encoded, not utf8.