### PR TITLE
add a `time_resolution` column to the output of `flux_read()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.5.0.9000
 Authors@R: c(
     person(c("Eric", "R."), "Scott", , "ericrscott@arizona.edu", role = "aut",
            comment = c(ORCID = "0000-0002-7430-7879")),
-    person(c("David", "J.P."), "Moore", role = c("aut", "cre"),
+    person(c("David", "J.P."), "Moore", , "davidjpmoore@arizona.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6462-3288")),
     person("Arizona Board of Regents on behalf of The University of Arizona", role = "cph",
            comment = c(ROR = "https://ror.org/0054f1w39"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * `flux_qc()` now works with hourly data by supplying a `threshold` of 0, 1, 2, or 3.
 * The `max_gapfill` argument to `flux_qc()` has been renamed to `threshold`
+* The output of `flux_read()` now includes a `time_resolution` column.  This may be especially useful for hourly (`"HR"`) and half-hourly (`"HH"`) frequency data, which are combined when `resolution = "h"`.
 
 # fluxnet 0.4.0
 

--- a/R/flux_read.R
+++ b/R/flux_read.R
@@ -85,10 +85,25 @@ flux_read <- function(
 
   cli::cli_inform("Reading {nrow(files_df)} file{?s}.")
   data_raw <- purrr::pmap(
-    files_df %>% dplyr::select(dplyr::all_of(c("path", "site_id", "dataset"))),
-    function(path, site_id, dataset) {
-      readr::read_csv(path, show_col_types = FALSE, na = c("", "NA", "-9999")) %>%
-        dplyr::mutate(site_id = site_id, dataset = dataset, .before = 1)
+    files_df %>%
+      dplyr::select(dplyr::all_of(c(
+        "path",
+        "site_id",
+        "dataset",
+        "time_resolution"
+      ))),
+    function(path, site_id, dataset, time_resolution) {
+      readr::read_csv(
+        path,
+        show_col_types = FALSE,
+        na = c("", "NA", "-9999")
+      ) %>%
+        dplyr::mutate(
+          site_id = site_id,
+          dataset = dataset,
+          time_resolution = time_resolution,
+          .before = 1
+        )
     },
     .progress = TRUE
   ) %>%


### PR DESCRIPTION
closes #79 